### PR TITLE
Remove code block from examples

### DIFF
--- a/messages/graphql.md
+++ b/messages/graphql.md
@@ -14,24 +14,22 @@ Run any valid GraphQL statement via the /graphql [API](https://developer.salesfo
 
 - Runs a mutation to create an Account, with an `example.txt` file, containing
 
-```text
-mutation AccountExample{
-  uiapi {
-    AccountCreate(input: {
-      Account: {
-        Name: "Trailblazer Express"
-      }
-    }) {
-      Record {
-        Id
-        Name {
-          value
+  mutation AccountExample{
+    uiapi {
+      AccountCreate(input: {
+        Account: {
+          Name: "Trailblazer Express"
+        }
+      }) {
+        Record {
+          Id
+          Name {
+            value
+          }
         }
       }
     }
   }
-}
-```
 
 <%= config.bin %> <%= command.id %> --body example.txt
 

--- a/messages/rest.md
+++ b/messages/rest.md
@@ -22,12 +22,10 @@ Make an authenticated HTTP request to Salesforce REST API and print the response
 
 - or with a file 'info.json' containing
 
-```json
-{
-  "Name": "Demo",
-  "ShippingCity": "Boise"
-}
-```
+  {
+    "Name": "Demo",
+    "ShippingCity": "Boise"
+  }
 
 <%= config.bin %> <%= command.id %> 'sobjects/account' --body info.json --method POST
 


### PR DESCRIPTION
### What does this PR do?
Using code blocks in examples will break the formatting on the README.md generation. This does not provide any additional useful formatting in the help text, so we will remove them here. 

Scroll down from here to see broken formatting: https://github.com/salesforcecli/cli/blob/2.57.5/README.md#sf-api-request-graphql

Example in help text (no additional formatting)
![screenshot_2024-08-26_at_4 38 58___pm_720](https://github.com/user-attachments/assets/36150211-f435-49f4-96bc-2d0b622d11b5)

### What issues does this PR fix or reference?
[skip-validate-pr]