### PR TITLE
fix(rest): update body req example

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -8,4 +8,4 @@ on:
 
 jobs:
   pr-validation:
-    uses: salesforcecli/github-workflows/.github/workflows/validatePR.yml@main
+    uses: salesforcecli/github-workflows/.github/workflows/validatePR.yml@ew/validate-wi-in-title

--- a/messages/rest.md
+++ b/messages/rest.md
@@ -63,8 +63,9 @@ Salesforce CLI defined this schema to be mimic Postman schemas; both share simil
 Here's a simple example of a JSON file that contains values for the request URL, method, and body:
 
 {
-"url": "sobjects/Account/<Account ID>",
+"url": "services/data/v61.0/sobjects/Account/<Account ID>",
 "method": "PATCH",
+"headers": ["content-type:application/json"],
 "body" : {
 "mode": "raw",
 "raw": {
@@ -81,4 +82,4 @@ HTTP header in "key:value" format.
 
 # flags.body.summary
 
-File or content for the body of the HTTP request. Specify "-" to read from standard input or "" for an empty body. If passing a file, prefix the filename with '@'. 
+File or content for the body of the HTTP request. Specify "-" to read from standard input or "" for an empty body. If passing a file, prefix the filename with '@'.


### PR DESCRIPTION
### What does this PR do?

Updates body req example in `api request rest`'s help text to:
* make the URL use the full endpoint (we started to require the `services/data/v61.0` recently)
* add `headers` (couldn't remember how I could set them). 

### What issues does this PR fix or reference?
@W-12345678@