### PR TITLE
feat: add `no-auth` flag W-18293634

### DIFF
--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -12,7 +12,7 @@
     "command": "api:request:rest",
     "flagAliases": [],
     "flagChars": ["H", "S", "X", "b", "f", "i", "o"],
-    "flags": ["body", "file", "flags-dir", "header", "include", "method", "stream-to-file", "target-org"],
+    "flags": ["body", "file", "flags-dir", "header", "include", "method", "no-auth", "stream-to-file", "target-org"],
     "plugin": "@salesforce/plugin-api"
   }
 ]

--- a/messages/rest.md
+++ b/messages/rest.md
@@ -81,4 +81,8 @@ HTTP header in "key:value" format.
 
 # flags.body.summary
 
-File or content for the body of the HTTP request. Specify "-" to read from standard input or "" for an empty body. If passing a file, prefix the filename with '@'. 
+File or content for the body of the HTTP request. Specify "-" to read from standard input or "" for an empty body. If passing a file, prefix the filename with '@'.
+
+# flags.no-auth.summary
+
+Skip the "Authentication" header.

--- a/messages/rest.md
+++ b/messages/rest.md
@@ -85,4 +85,4 @@ File or content for the body of the HTTP request. Specify "-" to read from stand
 
 # flags.no-auth.summary
 
-Skip the "Authentication" header.
+Don't add the "Authorization: Bearer <token>" header to the request.

--- a/src/commands/api/request/rest.ts
+++ b/src/commands/api/request/rest.ts
@@ -81,6 +81,9 @@ export class Rest extends SfCommand<void> {
       helpValue: 'file',
       char: 'b',
     }),
+    'no-auth': Flags.boolean({
+      summary: messages.getMessage('flags.no-auth.summary'),
+    }),
   };
 
   public static args = {
@@ -138,20 +141,27 @@ export class Rest extends SfCommand<void> {
       headers = { ...headers, ...body.getHeaders() };
     }
 
-    // refresh access token to ensure `got` gets a valid access token.
-    // TODO: we could skip this step if we used jsforce's HTTP module instead (handles expired tokens).
-    await org.refreshAuth();
+    const skipAuth = flags['no-auth'];
+    if (!skipAuth) {
+      // refresh access token to ensure `got` gets a valid access token.
+      // TODO: we could skip this step if we used jsforce's HTTP module instead (handles expired tokens).
+      await org.refreshAuth();
+    }
 
     const options = {
       agent: { https: new ProxyAgent() },
       method,
       headers: {
         ...SFDX_HTTP_HEADERS,
-        Authorization: `Bearer ${
-          // we don't care about apiVersion here, just need to get the access token.
-          // eslint-disable-next-line sf-plugin/get-connection-with-version
-          org.getConnection().getConnectionOptions().accessToken!
-        }`,
+        ...(skipAuth
+          ? {}
+          : {
+              Authorization: `Bearer ${
+                // we don't care about apiVersion here, just need to get the access token.
+                // eslint-disable-next-line sf-plugin/get-connection-with-version
+                org.getConnection().getConnectionOptions().accessToken!
+              }`,
+            }),
         ...headers,
       },
       body,


### PR DESCRIPTION
### What does this PR do?
Adds a `--no-auth` flag for `api request rest` to skip adding the `Authorization: Bearer <token>` header to requests.

Use cases:
### revoke oauth tokens:

https://help.salesforce.com/s/articleView?id=xcloud.remoteaccess_revoke_token.htm&type=5

Get the token from `sf org display` and:
```
sf api request rest services/oauth2/revoke --body "@token.txt" --header 'Content-Type: application/x-www-form-urlencoded' --include -X POST --no-auth
```

### other oauth endpoints
when playing with other oauth endpoints (requesting the initial access token, no need to auth)

### What issues does this PR fix or reference?
@W-18293634@
